### PR TITLE
Add unreachable path checks for Magmi

### DIFF
--- a/src/MageScan/Check/UnreachablePath.php
+++ b/src/MageScan/Check/UnreachablePath.php
@@ -45,6 +45,23 @@ class UnreachablePath extends AbstractCheck
     );
 
     /**
+     * Get all paths to be tested
+     *
+     * @param boolean $all
+     *
+     * @return string[]
+     */
+    public function getPaths($all = false)
+    {
+        $paths = $this->unreachablePathDefault;
+        if ($all) {
+            $paths += $this->unreachablePathMore;
+        }
+        sort($paths);
+        return $paths;
+    }
+
+    /**
      * More paths that we shouldn't be able to access
      *
      * @var array
@@ -61,8 +78,8 @@ class UnreachablePath extends AbstractCheck
         'app/etc/enterprise.xml',
         'chive',
         'composer.lock',
-        'magmi/web/magmi.php',
         'magmi/conf/magmi.ini',
+        'magmi/web/magmi.php',
         'info.php',
         'p.php',
         'README.txt',
@@ -89,23 +106,6 @@ class UnreachablePath extends AbstractCheck
         'var/log/payment_verisign.log',
         'var/report/',
     );
-
-    /**
-     * Get all paths to be tested
-     *
-     * @param boolean $all
-     *
-     * @return string[]
-     */
-    public function getPaths($all = false)
-    {
-        $paths = $this->unreachablePathDefault;
-        if ($all) {
-            $paths += $this->unreachablePathMore;
-        }
-        sort($paths);
-        return $paths;
-    }
 
     /**
      * Test that paths are inaccessible

--- a/src/MageScan/Check/UnreachablePath.php
+++ b/src/MageScan/Check/UnreachablePath.php
@@ -61,6 +61,8 @@ class UnreachablePath extends AbstractCheck
         'app/etc/enterprise.xml',
         'chive',
         'composer.lock',
+        'magmi/web/magmi.php',
+        'magmi/conf/magmi.ini',
         'info.php',
         'p.php',
         'README.txt',


### PR DESCRIPTION
Adds check for Magmi web UI (displays version number and potential sensitive information) as well as config file that contains DB usernames and passwords. This folder is often not properly secured and I have seen scripted attempts being blocked by Incapsula WAF due to a known security vulnerability in version < 0.7.20