### PR TITLE
Replaced shorthand array definition for PHP 5.3

### DIFF
--- a/src/MageScan/Check/Version/FileHash.php
+++ b/src/MageScan/Check/Version/FileHash.php
@@ -46,6 +46,6 @@ class FileHash extends AbstractCheck
         }
         $edition  = key($info);
         $versions = $info[$edition];
-        return [$edition, implode(', ', $versions)];
+        return array($edition, implode(', ', $versions));
     }
 }


### PR DESCRIPTION
Replaced shorthand array definition with normal array() declaration to make MageScan PHP 5.3 compatible... (I'm well aware that PHP 5.3 is end-of-life, but some LTS distributions still use it ****cringe****)