### PR TITLE
Replaced shorthand array definition for PHP 5.3

### DIFF
--- a/src/MageScan/Check/Patch/MageReport.php
+++ b/src/MageScan/Check/Patch/MageReport.php
@@ -44,13 +44,13 @@ class MageReport extends AbstractCheck
      *
      * @param array $patches
      */
-    public $patches = [
+    public $patches = array(
         'SUPEE-5344' => 'https://www.magereport.com/scan/result/supee5344',
         'SUPEE-5994' => 'https://www.magereport.com/scan/result/supee5994',
         'SUPEE-6285' => 'https://www.magereport.com/scan/result/supee6285',
         'SUPEE-6482' => 'https://www.magereport.com/scan/result/supee6482',
         'SUPEE-6788' => 'https://www.magereport.com/scan/result/supee6788',
-    ];
+    );
 
     /**
      * Set the URL


### PR DESCRIPTION
Replaced shorthand array definition with normal array() declaration to make MageScan PHP 5.3 compatible... (I'm well aware that PHP 5.3 is end-of-life, but some LTS distributions still use it ****cringe****)