### PR TITLE
Add media/dhl/info.php to unreachablepath.json

### DIFF
--- a/src/MageScan/config/unreachablepath.json
+++ b/src/MageScan/config/unreachablepath.json
@@ -37,6 +37,7 @@
     "manage/",
     "management/",
     "manager/",
+    "media/dhl/info.php",
     "modman",
     "p.php",
     "panel/",


### PR DESCRIPTION
Aloha,

First of all, thanks for your tool 🎉 

This PR aims to add a new file path to `unreachablepath.json`. The file `media/dhl/info.php` is a backdoor which is commonly found in Magento instances infected via SUPEE-5344 (aka. "Shoplift bug"). Without the right password, it's possible to call `phpinfo()`. With the right one, it's possible to execute arbitrary PHP code (via `eval()`). More details can be found at https://blog.sucuri.net/2015/04/magento-shoplift-supee-5344-exploits-in-the-wild.html.

I'll try to make a bigger list of Magento indicator of compromise that can be detected without requiring any kind of access and make another PR for it. I want to be sure that you will accept this "functionality" or if you want it to be in another module than _unreachablepath_ :-) 