### PR TITLE
Docker image support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Using PHP 7.2.* Alpine as base image
+
+FROM php:7.2-alpine
+
+# Setup default build arguments
+
+ARG RELEASE_VERSION=1.12.9
+
+# Install magescan phar executable
+
+RUN wget -O /usr/bin/magescan https://github.com/steverobbins/magescan/releases/download/v${RELEASE_VERSION}/magescan.phar
+RUN chmod +x /usr/bin/magescan
+
+# Check installed version during image build
+
+RUN magescan --version 
+
+# Setup entrypoint
+
+ENTRYPOINT [ "/usr/bin/magescan" ]
+
+

--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ Add the following to your `composer.json`
 }
 ```
 
+### Docker
+
+Download the latest version of `steverobbins/magescan` image:
+
+    $ docker pull steverobbins/magescan:latest
+
+Run a new Docker container from this image:
+
+    $ docker run --rm --name magescan steverobbins/magescan scan:all store.example.com
+
 # Usage
 
     $ magescan.phar scan:all store.example.com


### PR DESCRIPTION
I added a Dockerfile in order to build a Docker image to easily run this tool without installing or using it locally (that require PHP).

Documentation and example report an example of possible Docker image name `steverobbins/magescan` but, obviously, can be changed as you prefer.

In order to build this image you can run something like this:
```bash
docker build . -t steverobbins/magescan:latest --build-arg "RELEASE_VERSION=1.12.9"
docker push steverobbins/magescan:latest
```
where `"RELEASE_VERSION=1.12.9"` contain the released version to install inside the image and `:latest` is the Docker image tag. A better tag/version organization can be something like this:
```bash
docker build . -t steverobbins/magescan:1.12.9 --build-arg "RELEASE_VERSION=1.12.9"
docker push steverobbins/magescan:1.12.9
```
```bash
docker build . -t steverobbins/magescan:1.12.8 --build-arg "RELEASE_VERSION=1.12.8"
docker push steverobbins/magescan:1.12.8
```
and so on..